### PR TITLE
fix: update Cursor start command

### DIFF
--- a/src/cli/cursor.ts
+++ b/src/cli/cursor.ts
@@ -13,8 +13,8 @@ export async function configureCursor({
   const cursorConfigPath = path.join(os.homedir(), '.cursor', 'mcp.json');
 
   const baseMcpConfig = {
-    command: 'base-mcp',
-    args: [],
+    command: 'npx',
+    args: ['base-mcp'],
     env: {
       COINBASE_API_KEY_NAME: cdpKeyId,
       COINBASE_API_PRIVATE_KEY: cdpSecret,


### PR DESCRIPTION
## Description

This PR updates the start command for Cursor to match that of Claude and also align with common practice for MCP server start commands. Ex:
- https://github.com/JetBrains/mcp-jetbrains
- https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search