### PR TITLE
chore: bump AgentKit version

### DIFF
--- a/.changeset/two-taxis-feel.md
+++ b/.changeset/two-taxis-feel.md
@@ -1,0 +1,5 @@
+---
+'base-mcp': patch
+---
+
+Updated @coinbase/agentkit to v0.6.0 and removed override

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "packageManager": "yarn@4.5.1",
   "dependencies": {
     "@clack/prompts": "^0.10.0",
-    "@coinbase/agentkit": "^0.0.0-nightly-20250403210430",
+    "@coinbase/agentkit": "^0.6.0",
     "@coinbase/agentkit-model-context-protocol": "^0.2.0",
     "@coinbase/coinbase-sdk": "^0.21.0",
     "@coinbase/onchainkit": "^0.37.6",
@@ -74,10 +74,5 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
     "zod-to-json-schema": "^3.24.4"
-  },
-  "overrides": {
-    "@coinbase/agentkit-model-context-protocol": {
-      "@coinbase/agentkit": "^0.0.0-nightly-20250403210430"
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,9 +393,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/agentkit@npm:^0.0.0-nightly-20250403210430":
-  version: 0.0.0-nightly-20250403210430
-  resolution: "@coinbase/agentkit@npm:0.0.0-nightly-20250403210430"
+"@coinbase/agentkit@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@coinbase/agentkit@npm:0.6.0"
   dependencies:
     "@across-protocol/app-sdk": "npm:^0.2.0"
     "@alloralabs/allora-sdk": "npm:^0.1.0"
@@ -414,7 +414,7 @@ __metadata:
     twitter-api-v2: "npm:^1.18.2"
     viem: "npm:^2.22.16"
     zod: "npm:^3.23.8"
-  checksum: 10c0/9269be0bd2c0886361154ee2e6a4e33586189b25dfa86b239a44a27fe6f0f2759b3f67b8b3ec64cbc8b44c98f12ebecfae76a5a98fb70afaa349961a5f5dcc4d
+  checksum: 10c0/a530ab86195b984cdd413a44e4233acdb20de7a7add15eabeb27cef9b5eb92788ab347a02d48d73ca5fa4b0c416dd2ca7f41bf2fb8c13ef1fb4f22ecd4af52cf
   languageName: node
   linkType: hard
 
@@ -3090,7 +3090,7 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.28.1"
     "@clack/prompts": "npm:^0.10.0"
-    "@coinbase/agentkit": "npm:^0.0.0-nightly-20250403210430"
+    "@coinbase/agentkit": "npm:^0.6.0"
     "@coinbase/agentkit-model-context-protocol": "npm:^0.2.0"
     "@coinbase/coinbase-sdk": "npm:^0.21.0"
     "@coinbase/onchainkit": "npm:^0.37.6"


### PR DESCRIPTION
## Description

Updated `@coinbase/agentkit` to `v0.6.0` and removed override in `package.json`