### PR TITLE
Improve Error Handling for Unsupported Chains

### DIFF
--- a/src/tools/utils/index.ts
+++ b/src/tools/utils/index.ts
@@ -5,7 +5,7 @@ import { chainIdToChain } from '../../chains.js';
 export function constructBaseScanUrl(
   chain: Chain,
   transactionHash: `0x${string}`,
-) {
+): string {
   if (chain.id === base.id) {
     return `https://basescan.org/tx/${transactionHash}`;
   }
@@ -13,6 +13,8 @@ export function constructBaseScanUrl(
   if (chain.id === baseSepolia.id) {
     return `https://sepolia.basescan.org/tx/${transactionHash}`;
   }
+
+  throw new Error(`Unsupported chain ID: ${chain.id}`);
 }
 
 export const checkToolSupportsChain = ({


### PR DESCRIPTION
## Summary

- Updated `constructBaseScanUrl` to throw a clear `Error` when used with unsupported chains, preventing it from silently returning `undefined`.
- Added an explicit return type (`string`) to improve TypeScript type safety and clarity.
- Ensured better developer experience with helpful error messages that include the problematic `chain.id`.

## Testing

```bash
npm run lint   
npm run build
```
**Suggestions for Follow-up**

- Add unit tests for constructBaseScanUrl to ensure it handles both supported and unsupported chains as expected.
- Extend error logging for these thrown errors if they affect UX or debugging in production.

