### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Base MCP Server Contributors
+Copyright (c) 2026 Base MCP Server Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Annual copyright year update.

- Updated year: 2025 -> 2026
- Files affected: LICENSE