### PR TITLE
fix: add Dockerfile for Glama MCP directory listing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --only=production || npm install
+
+COPY . .
+RUN npm run build
+
+ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
Glama requires a Dockerfile to verify and list MCP servers in their directory. Added one so the server can be submitted for listing.